### PR TITLE
Display extra parameter for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ const WyreClient = require('wyre-api').WyreClient
 let wyre = new WyreClient({
     apiKey: "P334FCDXQ4UVAWVPUZ4V",
     secretKey: "4AZEWMYB7CFJWWZMCEWX"
+    //baseUrl: "https://api.testwyre.com"
 })
 
 wyre.get("/account")


### PR DESCRIPTION
Adding a commented out line indicating that a developer can provide the param 'baseUrl' to use the test api